### PR TITLE
Add buffer to over and hybrid methods

### DIFF
--- a/pytorch_resample/hybrid.py
+++ b/pytorch_resample/hybrid.py
@@ -15,6 +15,7 @@ class HybridSampler(torch.utils.data.IterableDataset):
             values are the desired class percentages. The values are normalised so that sum up
             to 1.
         sampling_rate: The fraction of data to use.
+        buffer_size: Size of the buffer.
         seed: Random seed for reproducibility.
 
     Attributes:
@@ -24,16 +25,18 @@ class HybridSampler(torch.utils.data.IterableDataset):
     """
 
     def __init__(self, dataset: torch.utils.data.IterableDataset, desired_dist: dict,
-                 sampling_rate: float, seed: int = None):
+                 sampling_rate: float, buffer_size: int = None, seed: int = None):
 
         self.dataset = dataset
         self.desired_dist = {c: p / sum(desired_dist.values()) for c, p in desired_dist.items()}
         self.sampling_rate = min(max(sampling_rate, 0), 1)
+        self.buffer_size = buffer_size
         self.seed = seed
 
         self.actual_dist = collections.Counter()
         self.rng = random.Random(seed)
         self._n = 0
+        self._buffer = {c: list() for c in desired_dist}
 
     def __iter__(self):
 
@@ -45,10 +48,18 @@ class HybridSampler(torch.utils.data.IterableDataset):
             f = self.desired_dist
             g = self.actual_dist
 
+            # Add to buffer
+            if self.buffer_size is not None:
+                self._buffer[y].append(x)
+                self._buffer[y] = self._buffer[y][-self.buffer_size:]
+
             rate = self.sampling_rate * f[y] / (g[y] / self._n)
 
             for _ in range(utils.random_poisson(rate, rng=self.rng)):
-                yield x, y
+                if self.buffer_size is None:
+                    yield x, y
+                else:
+                    yield self.rng.choice(self._buffer[y]), y
 
     @classmethod
     def expected_size(cls, n, sampling_rate):


### PR DESCRIPTION
As noted in the README, `OverSampler` and `HybridSampler` yield repeated samples one after the other. 

This PR introduces a `buffer` to solve this limitation:

Defining:
```python
import collections
import torch


class Dataset(torch.utils.data.IterableDataset):
    def __init__(self):
        super(Dataset, self).__init__()
        self.data = list(range(20))
        self.labels = [1] * 12 + [0] * 8
        
    def __iter__(self):
        for x, y in zip(self.data, self.labels):
            yield x, y

dataset = Dataset()
```

`OverSampler` without buffer:
```python
sample = OverSampler(
    dataset=dataset,
    desired_dist={0: .5, 1: .5},
    seed=42,
)

y_dist = collections.Counter()

batches = torch.utils.data.DataLoader(sample, batch_size=1)
outputs = list()
for xb, yb in batches:
    outputs.append(xb.item())

>>> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12, 12, 12, 12, 12, 12, 12, 12, 13, 13, 13, 14, 14, 14, 15, 15, 15, 16, 16, 18, 18, 18, 18, 19, 19]
```

`OverSampler` with buffer:
```python
sample = OverSampler(
    dataset=dataset,
    desired_dist={0: .5, 1: .5},
    buffer_size=10,
    seed=42,
)

y_dist = collections.Counter()

batches = torch.utils.data.DataLoader(sample, batch_size=1)
outputs = list()
for xb, yb in batches:
    outputs.append(xb.item())

>>> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12, 12, 12, 12, 12, 12, 12, 12, 13, 12, 13, 14, 13, 12, 12, 13, 14, 14, 13, 14, 12, 16, 13, 15, 17, 14, 18, 12]
```

`HybridSampler` can be compared the same way.